### PR TITLE
Proxying Request to Real Back-End

### DIFF
--- a/spawn/src/App.jsx
+++ b/spawn/src/App.jsx
@@ -18,7 +18,7 @@ function App() {
     }
 
     try {
-      const response = await fetch('https://spawn-app-back-end-production.up.railway.app/api/v1/betaAccessSignUp', {
+      const response = await fetch('/postRequest', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/spawn/vite.config.js
+++ b/spawn/vite.config.js
@@ -9,4 +9,14 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-})
+  server: {
+    proxy: {
+      "/postRequest": {
+        target:
+          "https://spawn-app-back-end-production.up.railway.app/api/v1/betaAccessSignUp",
+        changeOrigin: true, // Ensure the origin is changed to the target URL
+        rewrite: (path) => path.replace(/^\/postRequest/, ""), // Remove the /postRequest prefix
+      },
+    },
+  },
+});


### PR DESCRIPTION
Getting around vite's configurations for `fetch()` paths by specifying a proxy, per this Stackoverflow answer:

https://stackoverflow.com/a/69041080/13368695

## Proof that the button now works (our database received it)
Which you can check here (https://spawn-app-back-end-production.up.railway.app/api/v1/betaAccessSignUp)

<img width="692" alt="image" src="https://github.com/user-attachments/assets/7f9d1dbd-b229-4848-9a28-681701fa8d02" />

<img width="1039" alt="image" src="https://github.com/user-attachments/assets/eb5630f9-d48b-4fae-8b1e-8fa42f3267bd" />
